### PR TITLE
Residual error adder updates

### DIFF
--- a/scripts/tools/apply_wet_tropo_residual_error.py
+++ b/scripts/tools/apply_wet_tropo_residual_error.py
@@ -76,13 +76,10 @@ def main():
     utc_start_crossover = datetime(2021, 9, 1)
     utc_end_crossover = datetime(2022, 9, 1)
     utc_ref_simu = datetime(2000, 1, 1)
-    utc_date_simu = datetime(2019, 2, 5)
+    utc_date_simu = datetime(2019, 2, 1)
     
     diff_between_date = (utc_start_crossover-utc_ref_simu).total_seconds()
     diff_between_simulation_and_reference_crossover = (utc_date_simu-utc_start_crossover).total_seconds()
-    
-    repeat_cycle_period = 1802697.1564
-    nb_cycle_shift = diff_between_simulation_and_reference_crossover//repeat_cycle_period+1
 
     if diff_between_simulation_and_reference_crossover<0:
         print("Warning, Simulation date (",utc_date_simu,") is below crossover simulated start time : ", utc_start_crossover)
@@ -94,8 +91,9 @@ def main():
             print("Applying roll residual error")
 
             roll = Roll_module(parameters['roll_repository_name'])
-            # ~ roll.get_roll_file_associated_to_orbit_and_cycle(pass_number, cycle_number, delta_time = diff_between_date)
-            roll.get_roll_file_associated_to_orbit_and_cycle(pass_number, cycle_number, delta_time = diff_between_date+nb_cycle_shift*repeat_cycle_period)
+            roll.get_roll_file_associated_to_orbit_and_cycle(
+                pass_number, cycle_number,
+                delta_time=(utc_date_simu-utc_ref_simu).total_seconds())
             
             roll.interpolate_roll_on_sensor_grid(orbit_time)
             

--- a/scripts/tools/apply_wet_tropo_residual_error.py
+++ b/scripts/tools/apply_wet_tropo_residual_error.py
@@ -89,19 +89,17 @@ def main():
     try:
         if parameters['roll_repository_name'] != None:
             print("Applying roll residual error")
-
             roll = Roll_module(parameters['roll_repository_name'])
             roll.get_roll_file_associated_to_orbit_and_cycle(
                 pass_number, cycle_number,
                 delta_time=(utc_date_simu-utc_ref_simu).total_seconds())
-            
             roll.interpolate_roll_on_sensor_grid(orbit_time)
-            
             # Apply roll for each pixel
-            roll.interpolate_roll_on_pixelcloud(orbit_time, pixel_cloud_time, cross_track)
+            roll.interpolate_roll_on_pixelcloud(
+                orbit_time, pixel_cloud_time, cross_track,
+                bounds_error=False, fill_value=None)
             delta_h_roll = (roll.roll1_err_cloud)
             delta_h += delta_h_roll
-            
         else:
             print("No roll error applied")
     except:

--- a/scripts/tools/apply_wet_tropo_residual_error.py
+++ b/scripts/tools/apply_wet_tropo_residual_error.py
@@ -63,12 +63,19 @@ def main():
 
     delta_h = 0.
 
-    tropo = Tropo_module(parameters['Tropo model'], min(col), max(col), min(az), max(az), \
-    float(parameters['Tropo error stdv']), float(parameters['Tropo error mean']), float(parameters['Tropo error correlation']), \
-    parameters['Tropo error map file'])
+    try:
+        tropo_seed = parameters['Tropo seed']
+    except KeyError:
+        tropo_seed = None
 
+    tropo = Tropo_module(parameters['Tropo model'],
+                         min(col), max(col), min(az), max(az), \
+                         float(parameters['Tropo error stdv']),
+                         float(parameters['Tropo error mean']),
+                         float(parameters['Tropo error correlation']), \
+                         parameters['Tropo error map file'],
+                         seed=tropo_seed)
     tropo.generate_tropo_field_over_pass(min(lat))
-
     tropo.apply_tropo_error_on_pixels(az, col)
     tropo_2d_field = tropo.tropo_2d_field
     delta_h += tropo_2d_field        

--- a/sisimp/lib/roll_module.py
+++ b/sisimp/lib/roll_module.py
@@ -56,7 +56,8 @@ class Roll_module(object):
         self.lon_nadir=numpy.array(fid.variables['lon_nadir'])
         self.lat_nadir=numpy.array(fid.variables['lat_nadir'])
         self.roll1_err=numpy.array(fid.variables['roll_err'])
-        
+        self.xtrack=numpy.array(fid.variables['x_ac'])*1e3
+
         fid.close()
  
  
@@ -89,22 +90,13 @@ class Roll_module(object):
         # ~ print('self.lon_sens= ', self.lon_sens)
         # ~ print('self.lat_sens= ', self.lat_sens)
 
-    def interpolate_roll_on_pixelcloud(self, sensor_time, cloud_time, y):
-
-        # Estimate col where estimate the roll error: TBC
-        delta_xtrack = 120000./self.roll1_err.shape[1]
-        col = (y/delta_xtrack).astype('int')+self.roll1_err.shape[1]/2
-
-        self.roll1_err_cloud = np.zeros(len(cloud_time), float)
-        for i in range(self.roll1_err.shape[1]):
-            ind = np.where(col == i)
-            if ind[0].size:
-                # Interpolate roll variables on pixel cloud
-                
-                # ~ print("cloud_time", cloud_time)
-                # ~ print("sensor_time", sensor_time)
-                f=scipy.interpolate.interp1d(sensor_time,self.roll1_err_sens[i],kind='linear')
-                self.roll1_err_cloud[ind]=f(cloud_time[ind])
+    def interpolate_roll_on_pixelcloud(self, sensor_time, cloud_time, y,
+                                       bounds_error=False, fill_value=0):
+        # Interpolate roll variables on pixel cloud
+        self.roll1_err_cloud = scipy.interpolate.interpn(
+            (self.xtrack, sensor_time), np.array(self.roll1_err_sens),
+            (y, cloud_time), method='linear', bounds_error=bounds_error,
+            fill_value=fill_value)
 
 if __name__ == "__main__":
     

--- a/sisimp/lib/roll_module.py
+++ b/sisimp/lib/roll_module.py
@@ -8,26 +8,25 @@ import os
 import netCDF4 as nc
 import numpy
 import scipy.interpolate
-from matplotlib import pyplot 
+from matplotlib import pyplot
 import matplotlib.pyplot as plt
 import numpy as np
 import re
 import lib.my_api as my_api
 
-deltat=0. # time lag to be applied if reference time or pass number is different from CNES reference. 
-
+# time lag to be applied if reference time or pass number is different from CNES
+# reference.
+deltat=0.
 
 class Roll_module(object):
 
     def __init__(self, In_repository):
-   
         self.In_repository = In_repository
-        
 
-    def get_roll_file_associated_to_orbit_and_cycle(self, orbit_number, cycle_number, delta_time = 0):
+    def get_roll_file_associated_to_orbit_and_cycle(
+            self, orbit_number, cycle_number, delta_time=0):
         root_name = "GLOBAL_swot292_c"
-        
-        
+
         ############### VERY DIRTY FIX #################
         # ~ dt = 0
         # ~ orbit_number_shifted = orbit_number
@@ -37,21 +36,20 @@ class Roll_module(object):
             orbit_number_shifted+= 584
             dt = -784049.790623216
         ############### VERY DIRTY FIX #################
-        
-        # ~ print(orbit_number, orbit_number_shifted)
-        
-        file_name = os.path.join(self.In_repository, root_name + str(cycle_number).zfill(2) + "_p" + str(orbit_number_shifted).zfill(3)) +".nc"
+
+        file_name = os.path.join(self.In_repository, root_name \
+                                 + str(cycle_number).zfill(2) + "_p" \
+                                 + str(orbit_number_shifted).zfill(3)) +".nc"
         my_api.printInfo("Roll file used : %s " % file_name)
-        
+
         self.read_roll_file(file_name, delta_time = delta_time+dt)
 
     def read_roll_file(self, In_filename, delta_time = 0.):
-                
         try:
             fid = nc.Dataset(In_filename, 'r')
         except:
             raise Exception("Roll file not found")
-        
+
         self.time=numpy.array(fid.variables['time'])+delta_time
         self.lon_nadir=numpy.array(fid.variables['lon_nadir'])
         self.lat_nadir=numpy.array(fid.variables['lat_nadir'])
@@ -59,36 +57,30 @@ class Roll_module(object):
         self.xtrack=numpy.array(fid.variables['x_ac'])*1e3
 
         fid.close()
- 
- 
- 
+
     def interpolate_roll_on_sensor_grid(self, sensor_time):
-        
         self.roll1_err_sens = []
         self.lon_sens = []
         self.lat_sens = []
-        
-        print(sensor_time)
-        print(self.time)
-        
+
         for i in range(self.roll1_err.shape[1]):
             # Interpolate simulated roll variables on sensor time grid
-            
-            ensind=numpy.where(((self.time>=sensor_time[0]-2.)&(self.time<=sensor_time[-1]+2.)))
+            ensind=numpy.where(((self.time>=sensor_time[0]-2.) \
+                                & (self.time<=sensor_time[-1]+2.)))
             try:
-                f=scipy.interpolate.interp1d(self.time[ensind],(self.roll1_err[:,i])[ensind],kind='linear')
+                f=scipy.interpolate.interp1d(
+                    self.time[ensind], (self.roll1_err[:,i])[ensind], kind='linear')
             except:
-                print("time between crossover files and simulation time are not consistant")   
+                print("time between crossover files and simulation time are not consistent")
             self.roll1_err_sens.append(f(sensor_time))
-            
-        f2=scipy.interpolate.interp1d(self.time[ensind],(self.lon_nadir[:])[ensind],kind='linear')
+
+        f2=scipy.interpolate.interp1d(
+            self.time[ensind], (self.lon_nadir[:])[ensind], kind='linear')
         self.lon_sens.append(f2(sensor_time))
 
-        f3=scipy.interpolate.interp1d(self.time[ensind],(self.lat_nadir[:])[ensind],kind='linear')
+        f3=scipy.interpolate.interp1d(
+            self.time[ensind], (self.lat_nadir[:])[ensind], kind='linear')
         self.lat_sens.append(f3(sensor_time))
-            
-        # ~ print('self.lon_sens= ', self.lon_sens)
-        # ~ print('self.lat_sens= ', self.lat_sens)
 
     def interpolate_roll_on_pixelcloud(self, sensor_time, cloud_time, y,
                                        bounds_error=False, fill_value=0):
@@ -99,30 +91,30 @@ class Roll_module(object):
             fill_value=fill_value)
 
 if __name__ == "__main__":
-    
+
     #~ roll_file_err = '/work/ALT/swot/swototar/XOVERCAL/karin/GLOBAL_swot292_c16_p114.nc'
     #~ roll_file_cor = '/work/ALT/swot/swototar/XOVERCAL/roll_phase/roll_phase_c016_p114.nc'
     roll_file_err = '/work/ALT/swot/swototar/XOVERCAL/karin/GLOBAL_swot292_c16_p244.nc'
     roll_file_cor = '/work/ALT/swot/swototar/XOVERCAL/roll_phase/roll_phase_c016_p244.nc'
-    
+
     fid_err = nc.Dataset(roll_file_err, 'r')
     fid_cor = nc.Dataset(roll_file_cor, 'r')
-    
+
     time_err = numpy.array(fid_err.variables['time'])
     roll_err = numpy.array(fid_err.variables['roll_err'])*0
     phase_err = numpy.array(fid_err.variables['phase_err'])
     x_ac = (numpy.array(fid_err.variables['x_ac'])[:])*10e3
-    
-    time_cor = numpy.array(fid_cor.variables['time_karin'])    
+
+    time_cor = numpy.array(fid_cor.variables['time_karin'])
     sl1 = (numpy.array(fid_cor.variables['sl1']))*10e-6
     sl2 = (numpy.array(fid_cor.variables['sl2']))*10e-6
-     
+
     error_left = roll_err[:,0] + phase_err[:,0]
     error_right = roll_err[:,-1] + phase_err[:,-1]
-    
+
     corr_left = -(sl1-sl2)*x_ac[0]
     corr_right = -(sl1+sl2)*x_ac[-1]
-    
+
     plt.figure()
     plt.plot(phase_err[:,0])
     plt.figure()
@@ -136,7 +128,7 @@ if __name__ == "__main__":
     #~ plt.plot(corr_left)
     #~ plt.figure()
     #~ plt.plot(corr_right)
-    
+
     #~ plt.plot(x, error_left)
     #~ plt.plot(xp, error_right_p)
-    plt.show()   
+    plt.show()

--- a/sisimp/lib/tropo_module.py
+++ b/sisimp/lib/tropo_module.py
@@ -14,7 +14,6 @@ import lib.my_api as my_api
 
 
 class Tropo_module(object):
-
     def __init__(self, tropo_model, rmin, rmax, azmin, azmax, tropo_error_stdv,
                  tropo_error_mean, tropo_error_correlation,
                  tropo_error_map_file, seed=None):
@@ -39,7 +38,8 @@ class Tropo_module(object):
 
     def calculate_tropo_error_map(self, latmin):
 
-        my_api.printInfo("Computing map tropo_error field on %d x %d image" % (self.azmax-self.azmin, self.rmax-self.rmin))
+        my_api.printInfo("Computing map tropo_error field on %d x %d image"
+                         % (self.azmax-self.azmin, self.rmax-self.rmin))
 
         ds = nc.Dataset(self.tropo_error_map_file, 'r')
         delta_wtc_MEAN = ds.variables['delta_wtc_MEAN'][:]
@@ -47,11 +47,12 @@ class Tropo_module(object):
         latitude = ds.variables['latitude'][:]
 
         f=scipy.interpolate.interp1d(latitude, delta_wtc_MEAN,kind='linear')
-        delta_wtc_MEAN_local=f(latmin)        
+        delta_wtc_MEAN_local=f(latmin)
         f=scipy.interpolate.interp1d(latitude, delta_wtc_STD,kind='linear')
-        delta_wtc_STD_local=f(latmin) 
-               
-        my_api.printInfo("%f cm mean biais and %f cm stv  estimated at latitude %f" % (delta_wtc_MEAN_local, delta_wtc_STD_local, latmin))
+        delta_wtc_STD_local=f(latmin)
+
+        my_api.printInfo("%f cm mean bais and %f cm stv  estimated at latitude %f"
+                         % (delta_wtc_MEAN_local, delta_wtc_STD_local, latmin))
 
         self.tropo_map_rg_az = height_model.generate_2d_profile_gaussian(
             1, self.azmin, self.azmax+1, 1, self.rmin, self.rmax+1,
@@ -60,7 +61,6 @@ class Tropo_module(object):
 
     def apply_tropo_error_on_pixels(self, az, r):
         self.tropo_2d_field = self.tropo_map_rg_az[az-self.azmin,r-self.rmin]
-        
 
     def generate_tropo_field_over_pass(self, latmin):
         if self.model == 'gaussian':
@@ -69,5 +69,3 @@ class Tropo_module(object):
             self.calculate_tropo_error_map(latmin)
         else:
             self.tropo_map_rg_az = None
-        
-        

--- a/sisimp/lib/tropo_module.py
+++ b/sisimp/lib/tropo_module.py
@@ -15,22 +15,28 @@ import lib.my_api as my_api
 
 class Tropo_module(object):
 
-    def __init__(self, tropo_model, rmin, rmax, azmin, azmax, tropo_error_stdv, tropo_error_mean, tropo_error_correlation, tropo_error_map_file):
+    def __init__(self, tropo_model, rmin, rmax, azmin, azmax, tropo_error_stdv,
+                 tropo_error_mean, tropo_error_correlation,
+                 tropo_error_map_file, seed=None):
         self.model = tropo_model
         self.rmin = rmin
         self.rmax = rmax
         self.azmin = azmin
-        self.azmax = azmax       
+        self.azmax = azmax
         self.tropo_error_stdv = tropo_error_stdv
         self.tropo_error_mean = tropo_error_mean
         self.tropo_error_correlation = tropo_error_correlation
         self.tropo_error_map_file = tropo_error_map_file
-        
-    def calculate_tropo_error_gaussian(self):
+        self.seed = seed
 
-        my_api.printInfo("Computing random tropo_error field on %d x %d image" % (self.azmax-self.azmin, self.rmax-self.rmin))
-        self.tropo_map_rg_az = height_model.generate_2d_profile_gaussian(1, self.azmin, self.azmax+1, 1, self.rmin, self.rmax+1, self.tropo_error_stdv, lcorr = self.tropo_error_correlation)+ self.tropo_error_mean
-             
+    def calculate_tropo_error_gaussian(self):
+        my_api.printInfo("Computing random tropo_error field on %d x %d image"
+                         % (self.azmax-self.azmin, self.rmax-self.rmin))
+        self.tropo_map_rg_az = height_model.generate_2d_profile_gaussian(
+            1, self.azmin, self.azmax+1, 1, self.rmin, self.rmax+1,
+            self.tropo_error_stdv, lcorr=self.tropo_error_correlation,
+            seed=self.seed) + self.tropo_error_mean
+
     def calculate_tropo_error_map(self, latmin):
 
         my_api.printInfo("Computing map tropo_error field on %d x %d image" % (self.azmax-self.azmin, self.rmax-self.rmin))
@@ -47,8 +53,10 @@ class Tropo_module(object):
                
         my_api.printInfo("%f cm mean biais and %f cm stv  estimated at latitude %f" % (delta_wtc_MEAN_local, delta_wtc_STD_local, latmin))
 
-        self.tropo_map_rg_az = height_model.generate_2d_profile_gaussian(1, self.azmin, self.azmax+1, 1, self.rmin, self.rmax+1, delta_wtc_STD_local*0.01, lcorr = self.tropo_error_correlation)+delta_wtc_MEAN_local*0.01
-        
+        self.tropo_map_rg_az = height_model.generate_2d_profile_gaussian(
+            1, self.azmin, self.azmax+1, 1, self.rmin, self.rmax+1,
+            delta_wtc_STD_local*0.01, lcorr=self.tropo_error_correlation,
+            seed=self.seed) + delta_wtc_MEAN_local*0.01
 
     def apply_tropo_error_on_pixels(self, az, r):
         self.tropo_2d_field = self.tropo_map_rg_az[az-self.azmin,r-self.rmin]


### PR DESCRIPTION
Updates for adding residual errors
- Use correct delta time calculation for simulations to residual error script
- Added option for linear extrapolation in roll_module (default is to not extrapolate, and populate out-of-range values with 0s as before)
- Use crosstrack values from file in roll_module when interpolating, to properly account for the nadir gap
- Added option to specify a seed when calling tropo_module
- Added option to residual error script to generate tropo distribution for a range of records that may be larger than the pixel cloud extent (such that consistent errors can be added across multiple pixel clouds)
